### PR TITLE
Update Sysmon_OSSEC-Decoders.xml

### DIFF
--- a/Sysmon_OSSEC-Decoders.xml
+++ b/Sysmon_OSSEC-Decoders.xml
@@ -14,6 +14,6 @@
 <parent>windows</parent>
 <type>windows</type>
 <prematch>INFORMATION\(1\)</prematch>
-<regex offset="after_prematch">Image: (\.*) \s*CommandLine: \.* \s*User: (\.*) \s*LogonGuid: \S* \s*LogonId: \S* \s*TerminalSessionId: \S* \s*IntegrityLevel: \S* \s*HashType: \S* \s*Hash: (\S*) \s*ParentProcessGuid: \S* \s*ParentProcessID: \S* \s*ParentImage: (\.*) \s*ParentCommandLine:</regex>
+<regex offset="after_prematch">Image: (\.*) \s*CommandLine: \.* \s*User: (\.*) \s*LogonGuid: \S* \s*LogonId: \S* \s*TerminalSessionId: \S* \s*IntegrityLevel: \.*HashType: \S* \s*Hash: (\S*) \s*ParentProcessGuid: \S* \s*ParentProcessID: \S* \s*ParentImage: (\.*) \s*ParentCommandLine:</regex>
 <order>status,user,url,data</order>
 </decoder>


### PR DESCRIPTION
Allow for multiple words on IntegrityLevel:  On Windows 2003 logs, the integrity level passed is "no level".
